### PR TITLE
SwiftUI utilities: Font+Rubik, ButtonOutlineStyle, ObservableObject, FSCalendarRepresentable

### DIFF
--- a/ChangeSite/Calendar/FSCalendarRepresentable.swift
+++ b/ChangeSite/Calendar/FSCalendarRepresentable.swift
@@ -1,0 +1,280 @@
+//
+//  FSCalendarRepresentable.swift
+//  ChangeSite
+//
+//  Created by Emily Mittleman on 5/12/26.
+//  Copyright © 2026 Emily Mittleman. All rights reserved.
+//
+//  UIViewRepresentable wrapper for FSCalendar.
+//  Used as a placeholder in SwiftUI views until a first-party SwiftUI
+//  calendar solution is viable or FSCalendar ships a native SwiftUI wrapper.
+//
+//  Two modes:
+//    .week  — Home tab: week scope, scroll disabled, no month header
+//    .month — Calendar tab: month scope, horizontal scroll, custom cell coloring
+//
+//  TODO: revisit when FSCalendar ships a SwiftUI wrapper or a suitable
+//        first-party alternative becomes available.
+//
+
+import FSCalendar
+import SwiftUI
+
+// MARK: - Mode
+
+enum FSCalendarMode {
+  /// Week scope used on the Home tab: scrolling disabled, no header, single-week view.
+  case week
+  /// Month scope used on the Calendar tab: horizontal paging, custom cell coloring for
+  /// overdue dates and change dates.
+  case month
+}
+
+// MARK: - Representable
+
+struct FSCalendarRepresentable: UIViewRepresentable {
+
+  // MARK: Inputs
+
+  let mode: FSCalendarMode
+
+  /// Currently selected / highlighted date. In week mode the calendar marks
+  /// the pump site end date; in month mode selection is disabled.
+  @Binding var selectedDate: Date
+
+  /// Dates on which a site was started (marked with a circle stroke in month mode).
+  var changedSiteDates: Set<Date?>
+
+  /// Dates that were overdue (highlighted red background in month mode).
+  var overdueDates: Set<Date?>
+
+  // MARK: makeUIView
+
+  func makeUIView(context: Context) -> FSCalendar {
+    let calendar = FSCalendar()
+    calendar.dataSource = context.coordinator
+    calendar.delegate  = context.coordinator
+
+    // Shared appearance
+    calendar.backgroundColor = UIColor.custom.background
+    calendar.appearance.todayColor            = UIColor.custom.lightBlue
+    calendar.appearance.weekdayTextColor      = UIColor.custom.lightBlue
+    calendar.appearance.titleDefaultColor     = UIColor.custom.textPrimary
+    calendar.appearance.titleTodayColor       = UIColor.custom.background
+    calendar.appearance.headerTitleColor      = UIColor.custom.textTertiary
+    calendar.appearance.headerMinimumDissolvedAlpha = 0.0
+
+    switch mode {
+    case .week:
+      configureWeekMode(calendar)
+    case .month:
+      configureMonthMode(calendar, coordinator: context.coordinator)
+    }
+
+    return calendar
+  }
+
+  // MARK: updateUIView
+
+  func updateUIView(_ calendar: FSCalendar, context: Context) {
+    context.coordinator.changedSiteDates = changedSiteDates
+    context.coordinator.overdueDates     = overdueDates
+    context.coordinator.selectedDate     = selectedDate
+    calendar.reloadData()
+  }
+
+  // MARK: makeCoordinator
+
+  func makeCoordinator() -> Coordinator {
+    Coordinator(
+      mode: mode,
+      selectedDate: $selectedDate,
+      changedSiteDates: changedSiteDates,
+      overdueDates: overdueDates
+    )
+  }
+
+  // MARK: Private configuration helpers
+
+  private func configureWeekMode(_ calendar: FSCalendar) {
+    calendar.scope = .week
+    calendar.scrollEnabled = false
+    calendar.allowsSelection = false
+    calendar.today = .now
+    calendar.swipeToChooseGesture.isEnabled = false
+
+    // No month header in week mode
+    calendar.appearance.headerDateFormat = ""
+    calendar.appearance.headerMinimumDissolvedAlpha = 0.0
+
+    calendar.appearance.weekdayFont = UIFont(name: "Rubik-Regular", size: 15)
+    calendar.appearance.titleFont   = UIFont(name: "Rubik-Regular", size: 17)
+
+    calendar.register(CustomCalendarCell.self, forCellReuseIdentifier: "cell")
+  }
+
+  private func configureMonthMode(_ calendar: FSCalendar, coordinator: Coordinator) {
+    calendar.scope = .month
+    calendar.scrollDirection = .horizontal
+    calendar.allowsSelection = false
+    calendar.today = .now
+    calendar.swipeToChooseGesture.isEnabled = true
+
+    calendar.appearance.weekdayFont      = UIFont(name: "Rubik-Regular", size: 17)
+    calendar.appearance.titleFont        = UIFont(name: "Rubik-Regular", size: 15)
+    calendar.appearance.headerTitleFont  = UIFont(name: "Rubik-Regular", size: 20)
+
+    calendar.register(CustomCalendarCell.self, forCellReuseIdentifier: "cell")
+  }
+
+  // MARK: - Coordinator
+
+  final class Coordinator: NSObject, FSCalendarDataSource, FSCalendarDelegate {
+
+    let mode: FSCalendarMode
+    @Binding var selectedDate: Date
+    var changedSiteDates: Set<Date?>
+    var overdueDates: Set<Date?>
+
+    init(
+      mode: FSCalendarMode,
+      selectedDate: Binding<Date>,
+      changedSiteDates: Set<Date?>,
+      overdueDates: Set<Date?>
+    ) {
+      self.mode = mode
+      self._selectedDate = selectedDate
+      self.changedSiteDates = changedSiteDates
+      self.overdueDates = overdueDates
+    }
+
+    // MARK: FSCalendarDataSource
+
+    func calendar(
+      _ calendar: FSCalendar,
+      cellFor date: Date,
+      at position: FSCalendarMonthPosition
+    ) -> FSCalendarCell {
+      calendar.dequeueReusableCell(withIdentifier: "cell", for: date, at: position)
+    }
+
+    func calendar(
+      _ calendar: FSCalendar,
+      willDisplay cell: FSCalendarCell,
+      for date: Date,
+      at position: FSCalendarMonthPosition
+    ) {
+      configure(cell: cell, for: date, at: position)
+    }
+
+    // MARK: FSCalendarDelegate
+
+    func calendar(
+      _ calendar: FSCalendar,
+      boundingRectWillChange bounds: CGRect,
+      animated: Bool
+    ) {
+      // Allow FSCalendar to resize itself; the SwiftUI layout engine will
+      // pick up the intrinsic content size change on the next pass.
+      calendar.frame.size.height = bounds.height
+    }
+
+    // MARK: Private cell configuration
+
+    private func configure(
+      cell: FSCalendarCell,
+      for date: Date,
+      at position: FSCalendarMonthPosition
+    ) {
+      guard let cell = cell as? CustomCalendarCell else { return }
+
+      switch mode {
+      case .week:
+        configureWeekCell(cell, for: date, at: position)
+      case .month:
+        configureMonthCell(cell, for: date, at: position)
+      }
+    }
+
+    /// Week mode: mark only the current pump-site end date with a circle.
+    private func configureWeekCell(
+      _ cell: CustomCalendarCell,
+      for date: Date,
+      at position: FSCalendarMonthPosition
+    ) {
+      guard position == .current else {
+        cell.backgroundColor = .clear
+        cell.selectionLayer.isHidden = true
+        cell.isSelected = false
+        return
+      }
+
+      if isSameDay(date, selectedDate) {
+        cell.selectionLayer.isHidden = false
+        cell.isSelected = true
+      } else {
+        cell.selectionLayer.isHidden = true
+        cell.isSelected = false
+      }
+      cell.backgroundColor = .clear
+    }
+
+    /// Month mode: red background for overdue dates, circle for change dates.
+    private func configureMonthCell(
+      _ cell: CustomCalendarCell,
+      for date: Date,
+      at position: FSCalendarMonthPosition
+    ) {
+      guard position == .current else {
+        cell.backgroundColor = .clear
+        cell.selectionLayer.isHidden = true
+        cell.isSelected = false
+        return
+      }
+
+      // Overdue highlight
+      if overdueDates.contains(date) {
+        cell.backgroundColor = UIColor.custom.redHighlight
+      } else {
+        cell.backgroundColor = .clear
+      }
+
+      // Change-date circle
+      if changedSiteDates.contains(date) {
+        cell.selectionLayer.isHidden = false
+        cell.isSelected = true
+      } else {
+        cell.selectionLayer.isHidden = true
+        cell.isSelected = false
+      }
+    }
+
+    private func isSameDay(_ d1: Date, _ d2: Date) -> Bool {
+      Calendar.current.startOfDay(for: d1) == Calendar.current.startOfDay(for: d2)
+    }
+  }
+}
+
+// MARK: - Preview
+
+#Preview("FSCalendarRepresentable — week") {
+  FSCalendarRepresentable(
+    mode: .week,
+    selectedDate: .constant(Date()),
+    changedSiteDates: [],
+    overdueDates: []
+  )
+  .frame(height: 120)
+  .background(Color.custom.background)
+}
+
+#Preview("FSCalendarRepresentable — month") {
+  FSCalendarRepresentable(
+    mode: .month,
+    selectedDate: .constant(Date()),
+    changedSiteDates: [Calendar.current.date(byAdding: .day, value: -3, to: .now)],
+    overdueDates: [Calendar.current.date(byAdding: .day, value: -1, to: .now)]
+  )
+  .frame(height: 320)
+  .background(Color.custom.background)
+}

--- a/ChangeSite/Design/ButtonOutlineStyle.swift
+++ b/ChangeSite/Design/ButtonOutlineStyle.swift
@@ -1,0 +1,68 @@
+//
+//  ButtonOutlineStyle.swift
+//  ChangeSite
+//
+//  Created by Emily Mittleman on 5/12/26.
+//  Copyright © 2026 Emily Mittleman. All rights reserved.
+//
+//  Replicates the ButtonOutline image asset (a rounded-rect stroke in
+//  TextSecondary / light-blue) as a SwiftUI ViewModifier.
+//
+//  The source image shows a capsule-style rounded rectangle with:
+//    - A continuous, large corner radius (visually near-capsule)
+//    - A ~1.5 pt stroke in the app's TextSecondary (light blue) color
+//    - No fill
+//
+
+import SwiftUI
+
+// MARK: - ViewModifier
+
+/// Applies the ButtonOutline appearance: a rounded-rectangle stroke border
+/// matching the `ButtonOutline` image asset used by UIKit screens.
+struct ButtonOutlineStyle: ViewModifier {
+  /// Corner radius that matches the visual appearance of the ButtonOutline asset.
+  /// The image uses a near-capsule radius; 28 pt gives a pill shape on standard button heights.
+  var cornerRadius: CGFloat = 28
+  /// Stroke width matching the image asset border weight.
+  var lineWidth: CGFloat = 1.5
+
+  func body(content: Content) -> some View {
+    content
+      .overlay(
+        RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+          .strokeBorder(Color.custom.textSecondary, lineWidth: lineWidth)
+      )
+  }
+}
+
+// MARK: - View convenience
+
+extension View {
+  /// Applies the ButtonOutline stroke border (rounded rectangle, TextSecondary color).
+  func buttonOutlineStyle(cornerRadius: CGFloat = 28, lineWidth: CGFloat = 1.5) -> some View {
+    modifier(ButtonOutlineStyle(cornerRadius: cornerRadius, lineWidth: lineWidth))
+  }
+}
+
+// MARK: - Preview
+
+#Preview("ButtonOutlineStyle") {
+  VStack(spacing: 24) {
+    Text("Changed Site")
+      .rubik(.regular, 30)
+      .foregroundColor(Color.custom.textPrimary)
+      .frame(maxWidth: .infinity)
+      .frame(height: 56)
+      .buttonOutlineStyle()
+      .padding(.horizontal, 32)
+
+    Text("Save")
+      .rubik(.regular, 17)
+      .foregroundColor(Color.custom.textPrimary)
+      .frame(width: 120, height: 44)
+      .buttonOutlineStyle(cornerRadius: 22)
+  }
+  .padding()
+  .background(Color.custom.background)
+}

--- a/ChangeSite/Design/Font+Rubik.swift
+++ b/ChangeSite/Design/Font+Rubik.swift
@@ -1,0 +1,99 @@
+//
+//  Font+Rubik.swift
+//  ChangeSite
+//
+//  Created by Emily Mittleman on 5/12/26.
+//  Copyright © 2026 Emily Mittleman. All rights reserved.
+//
+//  Mirrors the widget's CSFont ViewModifier for the main app target,
+//  extended with Light weight and all sizes used across the app's screens.
+//
+
+import SwiftUI
+
+// MARK: - Weight enum
+
+extension Font {
+  /// Rubik font weight variants registered in the main app bundle.
+  enum RubikWeight {
+    case light    // Rubik-Light
+    case regular  // Rubik-Regular
+    case medium   // Rubik-Medium
+
+    var fontName: String {
+      switch self {
+      case .light:   return "Rubik-Light"
+      case .regular: return "Rubik-Regular"
+      case .medium:  return "Rubik-Medium"
+      }
+    }
+  }
+
+  /// Returns a Rubik font at the given size. Falls back to the system font if
+  /// the named font is unavailable (e.g., in Previews before the font is loaded).
+  static func rubik(_ weight: RubikWeight, _ size: CGFloat) -> Font {
+    if let uiFont = UIFont(name: weight.fontName, size: size) {
+      return Font(uiFont)
+    }
+    return .system(size: size)
+  }
+}
+
+// MARK: - Named scale instances
+
+extension Font {
+  // Launch
+  /// Rubik Medium 45 — launch screen H1
+  static let rubikLaunchH1     = Font.rubik(.medium, 45)
+
+  // Home countdown
+  /// Rubik Medium 40 — home tab countdown label
+  static let rubikCountdown    = Font.rubik(.medium, 40)
+
+  // Section headers
+  /// Rubik Medium 30 — large section header
+  static let rubikHeader30     = Font.rubik(.medium, 30)
+  /// Rubik Medium 28 — section header
+  static let rubikHeader28     = Font.rubik(.medium, 28)
+  /// Rubik Medium 26 — section header
+  static let rubikHeader26     = Font.rubik(.medium, 26)
+  /// Rubik Medium 25 — section header
+  static let rubikHeader25     = Font.rubik(.medium, 25)
+
+  // Body / buttons
+  /// Rubik Regular 30 — large button label
+  static let rubikBody30       = Font.rubik(.regular, 30)
+  /// Rubik Regular 25 — body / button label
+  static let rubikBody25       = Font.rubik(.regular, 25)
+  /// Rubik Regular 17 — standard body text
+  static let rubikBody17       = Font.rubik(.regular, 17)
+
+  // Bottom sheet
+  /// Rubik Medium 19 — bottom sheet / sheet title
+  static let rubikSheetTitle   = Font.rubik(.medium, 19)
+
+  // Tab bar
+  /// Rubik Light 12 — tab bar labels
+  static let rubikTabLabel     = Font.rubik(.light, 12)
+}
+
+// MARK: - ViewModifier
+
+/// Applies a Rubik font at the specified weight and size.
+struct RubikFontModifier: ViewModifier {
+  let weight: Font.RubikWeight
+  let size: CGFloat
+
+  func body(content: Content) -> some View {
+    content.font(.rubik(weight, size))
+  }
+}
+
+// MARK: - View convenience
+
+extension View {
+  /// Applies the Rubik font at the given weight and point size.
+  func rubik(_ weight: Font.RubikWeight, _ size: CGFloat) -> some View {
+    modifier(RubikFontModifier(weight: weight, size: size))
+  }
+}

--- a/ChangeSite/PumpSite/PumpSiteManager.swift
+++ b/ChangeSite/PumpSite/PumpSiteManager.swift
@@ -6,12 +6,13 @@
 //  Copyright © 2020 Emily Mittleman. All rights reserved.
 //
 
+import Combine
 import Foundation
 
 let defaultStartDate = Date.now
 let defaultDaysBtwn = 3
 
-public class PumpSiteManager {
+public class PumpSiteManager: ObservableObject {
   private let storage = UserDefaultsAccessHelper.sharedInstance
   #if !BUILDING_FOR_EXTENSION
   private let coreDataStack = AppDelegate.sharedAppDelegate.coreDataStack
@@ -35,6 +36,7 @@ public class PumpSiteManager {
   // MARK: Mutators
 
   public func setStartDate(_ date: Date) {
+    objectWillChange.send()
     self.startDate = date
     #if !BUILDING_FOR_EXTENSION
     SiteDates.createOrUpdate(pumpSite: getPumpSite(), endDate: nil, with: coreDataStack)
@@ -44,6 +46,7 @@ public class PumpSiteManager {
   }
 
   public func editStartDate(from oldDate: Date, to newDate: Date) {
+    objectWillChange.send()
     #if !BUILDING_FOR_EXTENSION
     // Delete old CoreData record keyed by oldDate
     SiteDates.delete(startDate: oldDate, with: coreDataStack)
@@ -65,6 +68,7 @@ public class PumpSiteManager {
     guard daysBtwnChanges >= 1 else {
       return
     }
+    objectWillChange.send()
     self.daysBtwn = daysBtwnChanges
     #if !BUILDING_FOR_EXTENSION
     SiteDates.createOrUpdate(pumpSite: getPumpSite(), endDate: nil, with: coreDataStack)
@@ -78,6 +82,7 @@ public class PumpSiteManager {
     guard storage.isNewUser() || changeDate > self.startDate || Bundle.main.isDebug else {
       return
     }
+    objectWillChange.send()
     #if !BUILDING_FOR_EXTENSION
     // End current site
     SiteDates.createOrUpdate(pumpSite: getPumpSite(), endDate: changeDate, with: coreDataStack)
@@ -88,6 +93,7 @@ public class PumpSiteManager {
   }
 
   public func setDefaultChangeTimme(_ changeTime: Date) {
+    objectWillChange.send()
     storage.set(changeTime, forKey: .defaultChangeTime)
 
     let hours = Calendar.current.component(.hour, from: changeTime)

--- a/ChangeSite/PumpSite/RemindersManager.swift
+++ b/ChangeSite/PumpSite/RemindersManager.swift
@@ -6,10 +6,11 @@
 //  Copyright © 2020 Emily Mittleman. All rights reserved.
 //
 
+import Combine
 import Foundation
 import UIKit
 
-class RemindersManager {
+class RemindersManager: ObservableObject {
 
   private var reminders = [ReminderType:Reminder]()
 
@@ -48,16 +49,19 @@ class RemindersManager {
   // MARK: Mutators, Setters, and Updaters
 
   public func updateReminder(type: ReminderType, frequency: ReminderFrequency) {
+    objectWillChange.send()
     reminders[type]!.frequency = frequency
     self.saveToStorage()
   }
 
   public func updateReminder(type: ReminderType, soundOn: Bool) {
+    objectWillChange.send()
     reminders[type]!.soundOn = soundOn
     self.saveToStorage()
   }
 
   public func updateReminder(type: ReminderType, repeatingFrequency: Date) {
+    objectWillChange.send()
     reminders[type]!.repeatingFrequency = repeatingFrequency
     self.saveToStorage()
   }


### PR DESCRIPTION
## Summary
- Adds `Font+Rubik.swift` — `Font.rubik(.weight, size)` factory + named static constants for all sizes used in the app (Rubik-Light/Regular/Medium)
- Adds `ButtonOutlineStyle.swift` — SwiftUI `ViewModifier` replicating the `ButtonOutline` UIImage button background used throughout UIKit screens
- Adds `ObservableObject` conformance to `PumpSiteManager` and `RemindersManager` via `objectWillChange.send()` in each mutating method (computed UserDefaults properties can't use `@Published`)
- Adds `FSCalendarRepresentable.swift` — `UIViewRepresentable` wrapping FSCalendar with `.week` (home tab) and `.month` (calendar tab) modes; coordinator implements `FSCalendarDataSource` + `FSCalendarDelegate`

## Test plan
- [ ] Build succeeds with no new warnings
- [ ] Rubik fonts render correctly (fallback to system font if not registered)
- [ ] `ButtonOutlineStyle` visually matches existing `ButtonOutline` image asset
- [ ] No regressions in existing UIKit screens that reference `PumpSiteManager` / `RemindersManager`

🤖 Generated with [Claude Code](https://claude.com/claude-code)