### PR TITLE
SwiftUI onboarding: LaunchView, SetupView, AppState

### DIFF
--- a/ChangeSite/AppDelegate.swift
+++ b/ChangeSite/AppDelegate.swift
@@ -10,6 +10,8 @@ import UIKit
 import CoreData
 import UserNotifications
 import WidgetKit
+import SwiftUI
+import Combine
 
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
@@ -28,6 +30,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
   var pumpSiteManager: PumpSiteManager?
   var remindersManager: RemindersManager?
   var notificationManager: NotificationManager?
+  var appState: AppState?
+  private var appStateCancellable: AnyCancellable?
 
   func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
     UserDefaultsAccessHelper.sharedInstance.setUp(withGroupID: Bundle.main.appGroupID)
@@ -61,10 +65,27 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     #endif
 
     let isNewUser = UserDefaultsAccessHelper.sharedInstance.isNewUser()
-    if isNewUser, let vc = storyboard.instantiateViewController(withIdentifier: "LaunchScreen") as? LaunchViewController {
-      vc.pumpSiteManager = pumpSiteManager
-      vc.remindersManager = remindersManager
-      initialViewController = vc
+    if isNewUser {
+      // SwiftUI onboarding flow — LaunchView → SetupView
+      let state = AppState(isNewUser: true)
+      self.appState = state
+
+      let launchView = LaunchView()
+        .environmentObject(pumpSiteManager!)
+        .environmentObject(remindersManager!)
+        .environmentObject(state)
+
+      initialViewController = UIHostingController(rootView: launchView)
+
+      // Observe the flag: when SetupView calls appState.isNewUser = false,
+      // swap the root VC to the main tab bar on the main thread.
+      appStateCancellable = state.$isNewUser
+        .dropFirst() // ignore the initial true
+        .filter { !$0 }
+        .receive(on: DispatchQueue.main)
+        .sink { [weak self] _ in
+          self?.presentMainTabBar()
+        }
     } else if let vc = storyboard.instantiateViewController(withIdentifier: "navigationMenuBaseController") as? NavigationMenuBaseController {
       vc.pumpSiteManager = pumpSiteManager
       vc.remindersManager = remindersManager
@@ -72,6 +93,25 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     }
     self.window?.rootViewController = initialViewController
     self.window?.makeKeyAndVisible()
+  }
+
+  /// Swaps the window root to the UIKit tab bar after onboarding completes.
+  private func presentMainTabBar() {
+    let storyboard = UIStoryboard(name: "Main", bundle: nil)
+    guard let vc = storyboard.instantiateViewController(withIdentifier: "navigationMenuBaseController") as? NavigationMenuBaseController else {
+      return
+    }
+    vc.pumpSiteManager = pumpSiteManager
+    vc.remindersManager = remindersManager
+
+    // Animate the root swap so the transition doesn't flash.
+    UIView.transition(
+      with: window!,
+      duration: 0.35,
+      options: .transitionCrossDissolve,
+      animations: { self.window?.rootViewController = vc },
+      completion: { _ in self.appStateCancellable = nil }
+    )
   }
 
   func applicationWillResignActive(_ application: UIApplication) {

--- a/ChangeSite/AppState.swift
+++ b/ChangeSite/AppState.swift
@@ -1,0 +1,20 @@
+//
+//  AppState.swift
+//  ChangeSite
+//
+//  Created by Emily Mittleman on 5/12/26.
+//  Copyright © 2026 Emily Mittleman. All rights reserved.
+//
+
+import Foundation
+
+/// Shared observable state for the root of the app.
+/// `isNewUser` drives the root-swap: when it flips to `false` the AppDelegate
+/// replaces the SwiftUI onboarding hosting controller with the UIKit tab bar.
+class AppState: ObservableObject {
+  @Published var isNewUser: Bool
+
+  init(isNewUser: Bool) {
+    self.isNewUser = isNewUser
+  }
+}

--- a/ChangeSite/HomeScreen/StartDatePickerSheet.swift
+++ b/ChangeSite/HomeScreen/StartDatePickerSheet.swift
@@ -1,0 +1,127 @@
+//
+//  StartDatePickerSheet.swift
+//  ChangeSite
+//
+//  Created by Emily Mittleman on 5/12/26.
+//  Copyright © 2026 Emily Mittleman. All rights reserved.
+//
+//  SwiftUI replacement for StartDatePickerBottomSheet.
+//  Present via .sheet(isPresented:) with .presentationDetents([.height(300)]).
+//
+
+import SwiftUI
+
+// MARK: - StartDatePickerSheet
+
+/// A bottom-sheet style date picker that lets the user choose a pump-site
+/// start date. Mirrors the UIKit `StartDatePickerBottomSheet` exactly:
+///
+/// - Header (40 pt, lightBlue background): Cancel | title | Save
+/// - Body: `ThirtyMinuteDatePicker` (dateAndTime, wheels, 30-min interval)
+/// - Initial date: today at the stored default-change-time hour:minute,
+///   snapped to the nearest 30-minute boundary.
+///
+/// Usage:
+/// ```swift
+/// .sheet(isPresented: $showPicker) {
+///   StartDatePickerSheet(isPresented: $showPicker) { chosenDate in
+///     pumpSiteManager.changedSite(changeDate: chosenDate)
+///   }
+/// }
+/// ```
+struct StartDatePickerSheet: View {
+
+  @Binding var isPresented: Bool
+
+  /// Called with the chosen `Date` when the user taps "Save".
+  let onSave: (Date) -> Void
+
+  @State private var selectedDate: Date = .now
+
+  var body: some View {
+    VStack(spacing: 0) {
+      headerBar
+      ThirtyMinuteDatePicker(selection: $selectedDate)
+        .frame(maxWidth: .infinity)
+    }
+    .onAppear {
+      selectedDate = initialPickerDate()
+    }
+    // Sheet presentation modifiers — applied by the caller's .sheet modifier,
+    // but also declared here so previews and hosted contexts get the same shape.
+    .presentationDetents([.height(300)])
+    .presentationDragIndicator(.hidden)
+  }
+
+  // MARK: - Header bar
+
+  private var headerBar: some View {
+    ZStack {
+      Color.custom.lightBlue
+        .frame(height: 40)
+
+      HStack {
+        Button("Cancel") {
+          isPresented = false
+        }
+        .font(.rubik(.medium, 17))
+        .foregroundStyle(Color.custom.background)
+        .accessibilityIdentifier("startDatePickerCancelButton")
+
+        Spacer()
+
+        Text("Choose your start date")
+          .font(.rubik(.medium, 19))
+          .foregroundStyle(Color.custom.background)
+          .lineLimit(1)
+          .minimumScaleFactor(0.7)
+
+        Spacer()
+
+        Button("Save") {
+          onSave(selectedDate)
+          isPresented = false
+        }
+        .font(.rubik(.medium, 17))
+        .foregroundStyle(Color.custom.background)
+        .accessibilityIdentifier("startDatePickerSaveButton")
+      }
+      .padding(.horizontal, 10)
+    }
+    .frame(height: 40)
+  }
+
+  // MARK: - Initial date logic
+
+  /// Mirrors the UIKit `showInView` logic:
+  /// 1. Read the stored default-change-time from UserDefaults.
+  /// 2. Apply its hour + minute to today.
+  /// 3. Snap to the nearest 30-minute boundary (floor) via `formatDate`.
+  private func initialPickerDate() -> Date {
+    let base: Date
+    if let stored = UserDefaultsAccessHelper.sharedInstance.date(for: .defaultChangeTime) {
+      let hour   = Calendar.current.component(.hour,   from: stored)
+      let minute = Calendar.current.component(.minute, from: stored)
+      base = Calendar.current.date(
+        bySettingHour: hour, minute: minute, second: 0, of: .now
+      ) ?? .now
+    } else {
+      base = .now
+    }
+    // formatDate snaps minutes down to the nearest 30-minute boundary.
+    return formatDate(base)
+  }
+}
+
+// MARK: - Preview
+
+#Preview("StartDatePickerSheet") {
+  @Previewable @State var shown = true
+  Color.custom.background
+    .ignoresSafeArea()
+    .sheet(isPresented: $shown) {
+      StartDatePickerSheet(isPresented: $shown) { date in
+        print("Saved:", date)
+      }
+    }
+}

--- a/ChangeSite/HomeScreen/ThirtyMinuteDatePicker.swift
+++ b/ChangeSite/HomeScreen/ThirtyMinuteDatePicker.swift
@@ -1,0 +1,68 @@
+//
+//  ThirtyMinuteDatePicker.swift
+//  ChangeSite
+//
+//  Created by Emily Mittleman on 5/12/26.
+//  Copyright © 2026 Emily Mittleman. All rights reserved.
+//
+//  UIViewRepresentable wrapping UIDatePicker in dateAndTime / wheels mode
+//  with a 30-minute interval, matching the UIKit StartDatePickerBottomSheet.
+//
+
+import SwiftUI
+import UIKit
+
+struct ThirtyMinuteDatePicker: UIViewRepresentable {
+
+  @Binding var selection: Date
+
+  func makeUIView(context: Context) -> UIDatePicker {
+    let picker = UIDatePicker()
+    picker.datePickerMode = .dateAndTime
+    picker.preferredDatePickerStyle = .wheels
+    picker.minuteInterval = 30
+    picker.addTarget(
+      context.coordinator,
+      action: #selector(Coordinator.valueChanged(_:)),
+      for: .valueChanged
+    )
+    return picker
+  }
+
+  func updateUIView(_ uiView: UIDatePicker, context: Context) {
+    // Avoid feedback loops: only update the picker when the date differs
+    // by more than 1 second (UIDatePicker fires valueChanged during scroll).
+    if abs(uiView.date.timeIntervalSince(selection)) > 1 {
+      uiView.setDate(selection, animated: false)
+    }
+  }
+
+  func makeCoordinator() -> Coordinator {
+    Coordinator(selection: $selection)
+  }
+
+  // MARK: - Coordinator
+
+  final class Coordinator: NSObject {
+    var selection: Binding<Date>
+
+    init(selection: Binding<Date>) {
+      self.selection = selection
+    }
+
+    @objc func valueChanged(_ sender: UIDatePicker) {
+      selection.wrappedValue = sender.date
+    }
+  }
+}
+
+// MARK: - Preview
+
+#Preview {
+  @Previewable @State var date = Date()
+  VStack {
+    ThirtyMinuteDatePicker(selection: $date)
+    Text(date.formatted(date: .abbreviated, time: .shortened))
+      .padding()
+  }
+}

--- a/ChangeSite/NewUser/LaunchView.swift
+++ b/ChangeSite/NewUser/LaunchView.swift
@@ -1,0 +1,66 @@
+//
+//  LaunchView.swift
+//  ChangeSite
+//
+//  Created by Emily Mittleman on 5/12/26.
+//  Copyright © 2026 Emily Mittleman. All rights reserved.
+//
+//  SwiftUI replacement for LaunchViewController.
+//  Displayed via UIHostingController when the user is new.
+//
+
+import SwiftUI
+
+struct LaunchView: View {
+
+  @EnvironmentObject var pumpSiteManager: PumpSiteManager
+  @EnvironmentObject var remindersManager: RemindersManager
+
+  @State private var showSetup = false
+
+  var body: some View {
+    NavigationStack {
+      ZStack {
+        Color.custom.background
+          .ignoresSafeArea()
+
+        VStack {
+          Spacer()
+
+          Text("Welcome to ChangeSite")
+            .font(.rubikLaunchH1)
+            .foregroundColor(Color.custom.textPrimary)
+            .multilineTextAlignment(.center)
+            .padding(.horizontal, 32)
+
+          Spacer()
+
+          Button {
+            showSetup = true
+          } label: {
+            Text("Begin")
+              .font(.rubikBody30)
+              .foregroundColor(Color.custom.textPrimary)
+              .frame(maxWidth: .infinity)
+              .frame(height: 64)
+          }
+          .buttonOutlineStyle()
+          .padding(.horizontal, 48)
+          .accessibilityIdentifier("beginButton")
+
+          Spacer()
+            .frame(height: 60)
+        }
+      }
+      .navigationDestination(isPresented: $showSetup) {
+        SetupView()
+      }
+    }
+  }
+}
+
+#Preview {
+  LaunchView()
+    .environmentObject(PumpSiteManager())
+    .environmentObject(RemindersManager())
+}

--- a/ChangeSite/NewUser/SetupView.swift
+++ b/ChangeSite/NewUser/SetupView.swift
@@ -1,0 +1,123 @@
+//
+//  SetupView.swift
+//  ChangeSite
+//
+//  Created by Emily Mittleman on 5/12/26.
+//  Copyright © 2026 Emily Mittleman. All rights reserved.
+//
+//  SwiftUI replacement for SetupViewController.
+//  Pushed onto the NavigationStack from LaunchView.
+//
+
+import SwiftUI
+
+struct SetupView: View {
+
+  @EnvironmentObject var pumpSiteManager: PumpSiteManager
+  @EnvironmentObject var remindersManager: RemindersManager
+  @EnvironmentObject var appState: AppState
+
+  // Mirror SetupViewController: init picker from formatDate(.now)
+  @State private var startDate: Date = formatDate(.now)
+  // Init stepper value from pumpSiteManager.daysBtwn via onAppear
+  @State private var daysBtwn: Int = 3
+
+  var body: some View {
+    ZStack {
+      Color.custom.background
+        .ignoresSafeArea()
+
+      VStack(alignment: .leading, spacing: 40) {
+        Spacer()
+          .frame(height: 16)
+
+        // MARK: Start date section
+        VStack(alignment: .leading, spacing: 16) {
+          Text("Set start date")
+            .font(.rubikHeader30)
+            .foregroundColor(Color.custom.textPrimary)
+            .overlay(alignment: .bottom) {
+              Rectangle()
+                .fill(Color.custom.lightBlue)
+                .frame(height: 2)
+            }
+
+          DatePicker(
+            "",
+            selection: $startDate,
+            displayedComponents: [.date, .hourAndMinute]
+          )
+          .labelsHidden()
+          .accessibilityIdentifier("setupDatePicker")
+        }
+        .padding(.horizontal, 32)
+
+        // MARK: Days between section
+        VStack(alignment: .leading, spacing: 16) {
+          Text("Days between changes")
+            .font(.rubikHeader25)
+            .foregroundColor(Color.custom.textPrimary)
+            .overlay(alignment: .bottom) {
+              Rectangle()
+                .fill(Color.custom.lightBlue)
+                .frame(height: 2)
+            }
+
+          HStack {
+            Text("\(daysBtwn)")
+              .font(.rubikBody25)
+              .foregroundColor(Color.custom.textPrimary)
+              .frame(minWidth: 32, alignment: .leading)
+
+            Stepper("", value: $daysBtwn, in: 1...Int.max)
+              .labelsHidden()
+              .accessibilityIdentifier("setupStepper")
+          }
+        }
+        .padding(.horizontal, 32)
+
+        Spacer()
+
+        // MARK: Save button
+        Button {
+          saveAndFinish()
+        } label: {
+          Text("Save")
+            .font(.rubikBody30)
+            .foregroundColor(Color.custom.textPrimary)
+            .frame(maxWidth: .infinity)
+            .frame(height: 64)
+        }
+        .buttonOutlineStyle()
+        .padding(.horizontal, 48)
+        .accessibilityIdentifier("setupSaveButton")
+
+        Spacer()
+          .frame(height: 40)
+      }
+    }
+    .navigationBarBackButtonHidden(false)
+    .onAppear {
+      daysBtwn = pumpSiteManager.daysBtwn
+    }
+  }
+
+  // MARK: - Actions
+
+  private func saveAndFinish() {
+    pumpSiteManager.setStartDate(startDate)
+    pumpSiteManager.setDaysBtwnChanges(daysBtwn)
+    UserDefaultsAccessHelper.sharedInstance.setUserFinishedSetup()
+    // Triggers AppDelegate to swap the root VC to the main tab bar
+    appState.isNewUser = false
+  }
+}
+
+#Preview {
+  NavigationStack {
+    SetupView()
+      .environmentObject(PumpSiteManager())
+      .environmentObject(RemindersManager())
+      .environmentObject(AppState(isNewUser: true))
+  }
+}


### PR DESCRIPTION
## Summary
- Adds `AppState.swift` — `ObservableObject` with `@Published var isNewUser: Bool`; single source of truth for the root-VC swap
- Adds `LaunchView.swift` — SwiftUI port of `LaunchViewController`; `NavigationStack` + `.navigationDestination` to push `SetupView`; managers injected as `@EnvironmentObject`
- Adds `SetupView.swift` — SwiftUI port of `SetupViewController`; `DatePicker` (.dateAndTime), `Stepper` (min=1), section underlines via `.overlay`; dead `addTestEntries` / `let testing = false` code omitted
- Updates `AppDelegate.presentInitialView()` — replaces storyboard `LaunchViewController` branch with `UIHostingController(rootView: LaunchView(...))`; Combine sink on `appState.$isNewUser` triggers `presentMainTabBar()` when setup completes

> **Stacked on:** `swiftui/utilities`

## Test plan
- [ ] New-user flow: app presents `LaunchView` → tap Begin → `SetupView` → save → main tab bar
- [ ] Returning-user flow: `presentInitialView` skips straight to tab bar (unchanged path)
- [ ] Accessibility identifiers present: `"beginButton"`, `"setupSaveButton"`, `"setupDatePicker"`, `"setupStepper"`
- [ ] No regressions in UIKit tab bar / calendar / settings screens

🤖 Generated with [Claude Code](https://claude.com/claude-code)