### PR TITLE
SwiftUI settings: StartDateView, DefaultChangeTimeView, ReminderFrequencyView, SettingsView

### DIFF
--- a/ChangeSite.xcodeproj/project.pbxproj
+++ b/ChangeSite.xcodeproj/project.pbxproj
@@ -33,12 +33,18 @@
 		5D8DF10C29343B0900FB2A48 /* LegendView.xib in Resources */ = {isa = PBXBuildFile; fileRef = 5D8DF10B29343B0900FB2A48 /* LegendView.xib */; };
 		5D9A0703292AF8F700B90AEE /* HomeViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5D9A0702292AF8F700B90AEE /* HomeViewModel.swift */; };
 		5DA3E8952C02DDAE003DDAB6 /* AppColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DA3E8942C02DDAE003DDAB6 /* AppColor.swift */; };
+		A1B2C3D4E5F6A7B8C9D0E1F2 /* Font+Rubik.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1A2B3C4D5E6F7A8B9C0D1E2 /* Font+Rubik.swift */; };
+		C3D4E5F6A7B8C9D0E1F2A3B4 /* ButtonOutlineStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = B2C3D4E5F6A7B8C9D0E1F2A3 /* ButtonOutlineStyle.swift */; };
 		5DA3E8962C02DDAE003DDAB6 /* AppColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DA3E8942C02DDAE003DDAB6 /* AppColor.swift */; };
 		5DA3E8992C02DF74003DDAB6 /* Media.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 5DA3E8982C02DF74003DDAB6 /* Media.xcassets */; };
 		5DA3E89A2C02DF74003DDAB6 /* Media.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 5DA3E8982C02DF74003DDAB6 /* Media.xcassets */; };
 		5DA3E89B2C03EB1E003DDAB6 /* Rubik-Medium.ttf in Resources */ = {isa = PBXBuildFile; fileRef = 5D6D2719291F957400BEC655 /* Rubik-Medium.ttf */; };
 		5DA3E89D2C04139F003DDAB6 /* StartDatePickerBottomSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DA3E89C2C04139F003DDAB6 /* StartDatePickerBottomSheet.swift */; };
 		5DAEB1F3299B461400A21251 /* DefaultChangeTimeController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DAEB1F2299B461400A21251 /* DefaultChangeTimeController.swift */; };
+		43405B321BC54B2A90828BE1 /* StartDateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D23048C2EEB3407B9BB0AAAC /* StartDateView.swift */; };
+		405B9E9CDDBE42149B518F1E /* DefaultChangeTimeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = E041AD1EF4094706BF366396 /* DefaultChangeTimeView.swift */; };
+		48DD92CBE83D44FFBA35CCCC /* ReminderFrequencyView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A940369CEE414AA2B4F393E6 /* ReminderFrequencyView.swift */; };
+		EDF353EC05EE4D99BAA96391 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = B658350569124D1BAF88ED3C /* SettingsView.swift */; };
 		5DB8911723003BCF0000BFC6 /* SettingsTableViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB8911623003BCF0000BFC6 /* SettingsTableViewController.swift */; };
 		5DB8911923003FE80000BFC6 /* StartDateController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB8911823003FE80000BFC6 /* StartDateController.swift */; };
 		5DB8911B2300401E0000BFC6 /* ReminderFrequencyController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5DB8911A2300401E0000BFC6 /* ReminderFrequencyController.swift */; };
@@ -138,9 +144,15 @@
 		5D8DF10B29343B0900FB2A48 /* LegendView.xib */ = {isa = PBXFileReference; lastKnownFileType = file.xib; path = LegendView.xib; sourceTree = "<group>"; };
 		5D9A0702292AF8F700B90AEE /* HomeViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HomeViewModel.swift; sourceTree = "<group>"; };
 		5DA3E8942C02DDAE003DDAB6 /* AppColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppColor.swift; sourceTree = "<group>"; };
+		F1A2B3C4D5E6F7A8B9C0D1E2 /* Font+Rubik.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Font+Rubik.swift"; sourceTree = "<group>"; };
+		B2C3D4E5F6A7B8C9D0E1F2A3 /* ButtonOutlineStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ButtonOutlineStyle.swift; sourceTree = "<group>"; };
 		5DA3E8982C02DF74003DDAB6 /* Media.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Media.xcassets; sourceTree = "<group>"; };
 		5DA3E89C2C04139F003DDAB6 /* StartDatePickerBottomSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartDatePickerBottomSheet.swift; sourceTree = "<group>"; };
 		5DAEB1F2299B461400A21251 /* DefaultChangeTimeController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultChangeTimeController.swift; sourceTree = "<group>"; };
+		D23048C2EEB3407B9BB0AAAC /* StartDateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartDateView.swift; sourceTree = "<group>"; };
+		E041AD1EF4094706BF366396 /* DefaultChangeTimeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultChangeTimeView.swift; sourceTree = "<group>"; };
+		A940369CEE414AA2B4F393E6 /* ReminderFrequencyView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReminderFrequencyView.swift; sourceTree = "<group>"; };
+		B658350569124D1BAF88ED3C /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
 		5DB8911623003BCF0000BFC6 /* SettingsTableViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsTableViewController.swift; sourceTree = "<group>"; };
 		5DB8911823003FE80000BFC6 /* StartDateController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StartDateController.swift; sourceTree = "<group>"; };
 		5DB8911A2300401E0000BFC6 /* ReminderFrequencyController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReminderFrequencyController.swift; sourceTree = "<group>"; };
@@ -253,6 +265,10 @@
 				5DB8911823003FE80000BFC6 /* StartDateController.swift */,
 				5DB8911A2300401E0000BFC6 /* ReminderFrequencyController.swift */,
 				5DAEB1F2299B461400A21251 /* DefaultChangeTimeController.swift */,
+					D23048C2EEB3407B9BB0AAAC /* StartDateView.swift */,
+					E041AD1EF4094706BF366396 /* DefaultChangeTimeView.swift */,
+					A940369CEE414AA2B4F393E6 /* ReminderFrequencyView.swift */,
+					B658350569124D1BAF88ED3C /* SettingsView.swift */,
 			);
 			path = Settings;
 			sourceTree = "<group>";
@@ -298,6 +314,8 @@
 			children = (
 				5D6D270F291F94AE00BEC655 /* Fonts */,
 				5DA3E8942C02DDAE003DDAB6 /* AppColor.swift */,
+				F1A2B3C4D5E6F7A8B9C0D1E2 /* Font+Rubik.swift */,
+				B2C3D4E5F6A7B8C9D0E1F2A3 /* ButtonOutlineStyle.swift */,
 				5DA3E8982C02DF74003DDAB6 /* Media.xcassets */,
 			);
 			path = Design;
@@ -661,11 +679,17 @@
 				CBDCC20F2B60EF8300BD995B /* PumpSiteUtils.swift in Sources */,
 				5DF50C4B292012EF00E3695C /* CoreDataStack.swift in Sources */,
 				5DAEB1F3299B461400A21251 /* DefaultChangeTimeController.swift in Sources */,
+				43405B321BC54B2A90828BE1 /* StartDateView.swift in Sources */,
+				405B9E9CDDBE42149B518F1E /* DefaultChangeTimeView.swift in Sources */,
+				48DD92CBE83D44FFBA35CCCC /* ReminderFrequencyView.swift in Sources */,
+				EDF353EC05EE4D99BAA96391 /* SettingsView.swift in Sources */,
 				5DF50C522920175D00E3695C /* SiteDates+CoreDataProperties.swift in Sources */,
 				5D1B011724C0635200EE9633 /* PumpSiteManager.swift in Sources */,
 				5D5CBC152C423E6C0034BC3D /* DebugViewController.swift in Sources */,
 				5DF50C5429202AD500E3695C /* CustomCalendarCell.swift in Sources */,
 				5DA3E8952C02DDAE003DDAB6 /* AppColor.swift in Sources */,
+				A1B2C3D4E5F6A7B8C9D0E1F2 /* Font+Rubik.swift in Sources */,
+				C3D4E5F6A7B8C9D0E1F2A3B4 /* ButtonOutlineStyle.swift in Sources */,
 				5DF50C512920175D00E3695C /* SiteDates+CoreDataClass.swift in Sources */,
 				5D9A0703292AF8F700B90AEE /* HomeViewModel.swift in Sources */,
 				5DB8911723003BCF0000BFC6 /* SettingsTableViewController.swift in Sources */,

--- a/ChangeSite/Navigation/TabItem.swift
+++ b/ChangeSite/Navigation/TabItem.swift
@@ -7,6 +7,7 @@
 //
 
 import Foundation
+import SwiftUI
 import UIKit
 
 enum TabItem {
@@ -24,12 +25,15 @@ enum TabItem {
     case .calendar(let pumpSiteManager):
       return CalendarViewController.viewController(pumpSiteManager: pumpSiteManager)
     case .settings(let pumpSiteManager, let remindersManager):
-      let navController = UINavigationController()
-      let settingsVC = SettingsTableViewController.viewController(pumpSiteManager: pumpSiteManager, remindersManager: remindersManager)
-      navController.viewControllers = [settingsVC]
-      return navController
+      let rootView = NavigationStack {
+        SettingsView()
+          .environmentObject(pumpSiteManager)
+          .environmentObject(remindersManager)
+      }
+      let hostingController = UIHostingController(rootView: rootView)
+      return hostingController
     #if DEBUG
-    case .debug(let pumpSiteManager, let remindersManager):
+    case .debug:
       return DebugViewController()
     #endif
     }

--- a/ChangeSite/Settings/DefaultChangeTimeView.swift
+++ b/ChangeSite/Settings/DefaultChangeTimeView.swift
@@ -1,0 +1,99 @@
+//
+//  DefaultChangeTimeView.swift
+//  ChangeSite
+//
+//  Created by Emily Mittleman on 5/12/26.
+//  Copyright © 2026 Emily Mittleman. All rights reserved.
+//
+
+import SwiftUI
+
+struct DefaultChangeTimeView: View {
+
+  @EnvironmentObject var pumpSiteManager: PumpSiteManager
+  @Environment(\.dismiss) private var dismiss
+
+  @State private var selectedTime: Date
+  private let originalTime: Date
+
+  init() {
+    let stored = UserDefaultsAccessHelper.sharedInstance.date(for: .defaultChangeTime) ?? .now
+    self.originalTime = stored
+    _selectedTime = State(initialValue: stored)
+  }
+
+  private var hasChanges: Bool {
+    !Calendar.current.isDate(selectedTime, equalTo: originalTime, toGranularity: .minute)
+  }
+
+  var body: some View {
+    ZStack(alignment: .top) {
+      Color.custom.background
+        .ignoresSafeArea()
+
+      VStack(spacing: 32) {
+        // Title with lightBlue bottom underline
+        VStack(alignment: .leading, spacing: 0) {
+          Text("Set Default Change Time")
+            .font(.rubikHeader28)
+            .foregroundColor(Color.custom.textPrimary)
+
+          Rectangle()
+            .fill(Color.custom.lightBlue)
+            .frame(height: 2)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 24)
+        .padding(.top, 24)
+
+        DatePicker(
+          "",
+          selection: $selectedTime,
+          displayedComponents: .hourAndMinute
+        )
+        .labelsHidden()
+        .datePickerStyle(.wheel)
+        .padding(.horizontal, 24)
+
+        if hasChanges {
+          Button {
+            pumpSiteManager.setDefaultChangeTimme(selectedTime)
+            dismiss()
+          } label: {
+            Text("Save")
+              .font(.rubikBody30)
+              .foregroundColor(Color.custom.textPrimary)
+              .frame(maxWidth: .infinity)
+              .frame(height: 56)
+              .buttonOutlineStyle()
+          }
+          .padding(.horizontal, 48)
+          .transition(.opacity)
+        }
+
+        Spacer()
+      }
+    }
+    .animation(.easeInOut(duration: 0.2), value: hasChanges)
+  }
+}
+
+// MARK: - Preview
+
+#Preview("DefaultChangeTimeView") {
+  let manager = PumpSiteManager()
+  return NavigationStack {
+    DefaultChangeTimeView()
+      .environmentObject(manager)
+  }
+  .preferredColorScheme(.light)
+}
+
+#Preview("DefaultChangeTimeView — dark") {
+  let manager = PumpSiteManager()
+  return NavigationStack {
+    DefaultChangeTimeView()
+      .environmentObject(manager)
+  }
+  .preferredColorScheme(.dark)
+}

--- a/ChangeSite/Settings/ReminderFrequencyView.swift
+++ b/ChangeSite/Settings/ReminderFrequencyView.swift
@@ -1,0 +1,235 @@
+//
+//  ReminderFrequencyView.swift
+//  ChangeSite
+//
+//  Created by Emily Mittleman on 5/12/26.
+//  Copyright © 2026 Emily Mittleman. All rights reserved.
+//
+
+import SwiftUI
+import UserNotifications
+
+struct ReminderFrequencyView: View {
+
+  // MARK: - Dependencies
+
+  @EnvironmentObject var remindersManager: RemindersManager
+  @Environment(\.dismiss) private var dismiss
+
+  let reminderType: ReminderType
+
+  // MARK: - State
+
+  @State private var selectedFrequency: ReminderFrequency
+  @State private var soundOn: Bool
+  @State private var repeatingTime: Date
+  @State private var showNotificationsAlert = false
+  @State private var hasChanges = false
+
+  // Tracks the values at init so we can detect changes.
+  private let originalFrequency: ReminderFrequency
+  private let originalSoundOn: Bool
+  private let originalRepeatingTime: Date
+
+  // MARK: - Init
+
+  init(reminderType: ReminderType, remindersManager: RemindersManager) {
+    self.reminderType = reminderType
+    let freq = remindersManager.getFrequency(type: reminderType)
+    let sound = remindersManager.getSoundOn(type: reminderType)
+    let repeating = remindersManager.getRepeatingFrequency(type: reminderType)
+    self.originalFrequency = freq
+    self.originalSoundOn = sound
+    self.originalRepeatingTime = repeating
+    _selectedFrequency = State(initialValue: freq)
+    _soundOn = State(initialValue: sound)
+    _repeatingTime = State(initialValue: repeating)
+  }
+
+  // MARK: - Body
+
+  var body: some View {
+    ZStack(alignment: .top) {
+      Color.custom.background
+        .ignoresSafeArea()
+
+      VStack(alignment: .leading, spacing: 32) {
+        // Title with lightBlue bottom underline
+        VStack(alignment: .leading, spacing: 0) {
+          Text(reminderType.displayTitle)
+            .font(.rubikHeader30)
+            .foregroundColor(Color.custom.textPrimary)
+
+          Rectangle()
+            .fill(Color.custom.lightBlue)
+            .frame(height: 2)
+        }
+        .padding(.horizontal, 24)
+        .padding(.top, 24)
+
+        // Frequency picker (segmented)
+        Picker("Frequency", selection: $selectedFrequency) {
+          Text(ReminderFrequency.none.rawValue.capitalized)
+            .tag(ReminderFrequency.none)
+          Text(ReminderFrequency.single.rawValue.capitalized)
+            .tag(ReminderFrequency.single)
+          Text(ReminderFrequency.repeating.rawValue.capitalized)
+            .tag(ReminderFrequency.repeating)
+        }
+        .pickerStyle(.segmented)
+        .padding(.horizontal, 24)
+        .onChange(of: selectedFrequency) { _, newValue in
+          handleFrequencyChange(newValue)
+        }
+
+        // Sound toggle — visible when frequency != .none
+        if selectedFrequency != .none {
+          HStack {
+            Text("Sound")
+              .font(.rubikHeader26)
+              .foregroundColor(Color.custom.textPrimary)
+
+            Spacer()
+
+            Toggle("", isOn: $soundOn)
+              .labelsHidden()
+              .onChange(of: soundOn) { _, _ in
+                hasChanges = true
+              }
+          }
+          .padding(.horizontal, 24)
+          .transition(.opacity)
+        }
+
+        // Repeating interval picker — visible only when frequency == .repeating
+        if selectedFrequency == .repeating {
+          VStack(alignment: .leading, spacing: 8) {
+            Text("Remind me every")
+              .font(.rubikHeader26)
+              .foregroundColor(Color.custom.textPrimary)
+              .padding(.horizontal, 24)
+
+            DatePicker(
+              "",
+              selection: $repeatingTime,
+              displayedComponents: .hourAndMinute
+            )
+            .labelsHidden()
+            .datePickerStyle(.wheel)
+            .padding(.horizontal, 24)
+            .onChange(of: repeatingTime) { _, _ in
+              hasChanges = true
+            }
+          }
+          .transition(.opacity)
+        }
+
+        // Save button — visible when any value has changed
+        if hasChanges {
+          Button {
+            saveAndDismiss()
+          } label: {
+            Text("Save")
+              .font(.rubikBody30)
+              .foregroundColor(Color.custom.textPrimary)
+              .frame(maxWidth: .infinity)
+              .frame(height: 56)
+              .buttonOutlineStyle()
+          }
+          .padding(.horizontal, 48)
+          .transition(.opacity)
+        }
+
+        Spacer()
+      }
+    }
+    .animation(.easeInOut(duration: 0.2), value: selectedFrequency)
+    .animation(.easeInOut(duration: 0.2), value: hasChanges)
+    .alert("Enable Notifications", isPresented: $showNotificationsAlert) {
+      Button("Cancel", role: .cancel) { }
+      Button("Settings") {
+        if let url = URL(string: UIApplication.openSettingsURLString) {
+          UIApplication.shared.open(url)
+        }
+      }
+    } message: {
+      Text("In order to set up reminders, please go to settings to enable notifications.")
+    }
+    .onAppear {
+      NotificationManager.shared.fetchNotificationSettings()
+    }
+  }
+
+  // MARK: - Private helpers
+
+  private func handleFrequencyChange(_ newFrequency: ReminderFrequency) {
+    guard newFrequency != .none else {
+      // Moving to .none is always allowed.
+      hasChanges = true
+      return
+    }
+
+    // Check if notifications are enabled before allowing a non-none selection.
+    UNUserNotificationCenter.current().getNotificationSettings { settings in
+      DispatchQueue.main.async {
+        if settings.authorizationStatus == .authorized {
+          hasChanges = true
+        } else {
+          // Revert the picker and show the alert.
+          selectedFrequency = originalFrequency == .none ? .none : originalFrequency
+          showNotificationsAlert = true
+        }
+      }
+    }
+  }
+
+  private func saveAndDismiss() {
+    // Normalize the repeating time to zero seconds (mirrors the UIKit getRepeatingFromDatePicker logic).
+    let hours = Calendar.current.component(.hour, from: repeatingTime)
+    let minutes = Calendar.current.component(.minute, from: repeatingTime)
+    let normalizedRepeating = Calendar.current.date(
+      bySettingHour: hours, minute: minutes, second: 0, of: .now
+    ) ?? repeatingTime
+
+    remindersManager.updateReminder(type: reminderType, frequency: selectedFrequency)
+    remindersManager.updateReminder(type: reminderType, soundOn: soundOn)
+    remindersManager.updateReminder(type: reminderType, repeatingFrequency: normalizedRepeating)
+    NotificationManager.shared.rescheduleNotifications([reminderType])
+    dismiss()
+  }
+}
+
+// MARK: - ReminderType display helpers
+
+private extension ReminderType {
+  var displayTitle: String {
+    switch self {
+    case .oneDayBefore:    return "1 Day Before"
+    case .dayOf:           return "Day Of"
+    case .oneDayAfter:     return "1 Day After"
+    case .twoDaysAfter:    return "2 Days After"
+    case .extendedDaysAfter: return "3+ Days After"
+    }
+  }
+}
+
+// MARK: - Preview
+
+#Preview("ReminderFrequencyView — dayOf") {
+  let remindersManager = RemindersManager()
+  return NavigationStack {
+    ReminderFrequencyView(reminderType: .dayOf, remindersManager: remindersManager)
+      .environmentObject(remindersManager)
+  }
+  .preferredColorScheme(.light)
+}
+
+#Preview("ReminderFrequencyView — repeating") {
+  let remindersManager = RemindersManager()
+  remindersManager.updateReminder(type: .oneDayAfter, frequency: .repeating)
+  return NavigationStack {
+    ReminderFrequencyView(reminderType: .oneDayAfter, remindersManager: remindersManager)
+      .environmentObject(remindersManager)
+  }
+  .preferredColorScheme(.dark)
+}

--- a/ChangeSite/Settings/SettingsView.swift
+++ b/ChangeSite/Settings/SettingsView.swift
@@ -1,0 +1,179 @@
+//
+//  SettingsView.swift
+//  ChangeSite
+//
+//  Created by Emily Mittleman on 5/12/26.
+//  Copyright © 2026 Emily Mittleman. All rights reserved.
+//
+
+import SwiftUI
+
+struct SettingsView: View {
+
+  // MARK: - Dependencies
+
+  @EnvironmentObject var pumpSiteManager: PumpSiteManager
+  @EnvironmentObject var remindersManager: RemindersManager
+
+  // MARK: - Local state for the stepper
+
+  /// Mirrors `pumpSiteManager.daysBtwn` so the stepper binding stays responsive
+  /// without a published property on PumpSiteManager.
+  @State private var daysBtwn: Int = 3
+
+  // MARK: - Formatted display values
+
+  private var formattedStartDate: String {
+    let formatter = DateFormatter()
+    formatter.dateStyle = .short
+    formatter.timeStyle = .short
+    return formatter.string(from: pumpSiteManager.startDate)
+  }
+
+  private var formattedDefaultChangeTime: String {
+    if let time = UserDefaultsAccessHelper.sharedInstance.date(for: .defaultChangeTime) {
+      let formatter = DateFormatter()
+      formatter.dateStyle = .none
+      formatter.timeStyle = .short
+      return formatter.string(from: time)
+    }
+    return "Off"
+  }
+
+  // MARK: - Body
+
+  var body: some View {
+    List {
+      // ---- Section 1: Pump site timing ----
+      Section {
+        // Start date row
+        NavigationLink {
+          StartDateView(pumpSiteManager: pumpSiteManager)
+            .environmentObject(pumpSiteManager)
+        } label: {
+          HStack {
+            Text("Start Date")
+              .font(.rubikBody17)
+              .foregroundColor(Color.custom.textPrimary)
+            Spacer()
+            Text(formattedStartDate)
+              .font(.rubikBody17)
+              .foregroundColor(Color.custom.textSecondary)
+          }
+        }
+        .accessibilityIdentifier("settings.startDateRow")
+
+        // Days between row — inline stepper
+        HStack {
+          Text("Days Between Changes")
+            .font(.rubikBody17)
+            .foregroundColor(Color.custom.textPrimary)
+          Spacer()
+          Text("\(daysBtwn)")
+            .font(.rubikBody17)
+            .foregroundColor(Color.custom.textSecondary)
+          Stepper("", value: $daysBtwn, in: 1...30)
+            .labelsHidden()
+            .onChange(of: daysBtwn) { _, newValue in
+              pumpSiteManager.setDaysBtwnChanges(newValue)
+            }
+        }
+        .accessibilityIdentifier("settings.daysBetweenRow")
+
+        // Default change time row
+        NavigationLink {
+          DefaultChangeTimeView()
+            .environmentObject(pumpSiteManager)
+        } label: {
+          HStack {
+            Text("Default Change Time")
+              .font(.rubikBody17)
+              .foregroundColor(Color.custom.textPrimary)
+            Spacer()
+            Text(formattedDefaultChangeTime)
+              .font(.rubikBody17)
+              .foregroundColor(Color.custom.textSecondary)
+          }
+        }
+        .accessibilityIdentifier("settings.defaultChangeTimeRow")
+      }
+      .listRowBackground(Color.custom.background)
+
+      // ---- Section 2: Reminders ----
+      Section(header:
+        Text("Reminders")
+          .font(.rubikBody17)
+          .foregroundColor(Color.custom.textSecondary)
+      ) {
+        ForEach(ReminderType.allCases, id: \.rawValue) { reminderType in
+          NavigationLink {
+            ReminderFrequencyView(
+              reminderType: reminderType,
+              remindersManager: remindersManager
+            )
+            .environmentObject(remindersManager)
+          } label: {
+            HStack {
+              Text(reminderType.settingsRowTitle)
+                .font(.rubikBody17)
+                .foregroundColor(Color.custom.textPrimary)
+              Spacer()
+              Text(remindersManager.getFrequency(type: reminderType).rawValue.capitalized)
+                .font(.rubikBody17)
+                .foregroundColor(Color.custom.textSecondary)
+            }
+          }
+          .accessibilityIdentifier("settings.reminder.\(reminderType.rawValue)")
+        }
+      }
+      .listRowBackground(Color.custom.background)
+    }
+    .listStyle(.insetGrouped)
+    .scrollContentBackground(.hidden)
+    .background(Color.custom.background)
+    .navigationTitle("Settings")
+    .navigationBarTitleDisplayMode(.large)
+    .onAppear {
+      // Sync local stepper state with manager (in case another screen mutated daysBtwn).
+      daysBtwn = pumpSiteManager.daysBtwn
+    }
+  }
+}
+
+// MARK: - ReminderType display helpers
+
+private extension ReminderType {
+  var settingsRowTitle: String {
+    switch self {
+    case .oneDayBefore:      return "1 Day Before"
+    case .dayOf:             return "Day Of"
+    case .oneDayAfter:       return "1 Day After"
+    case .twoDaysAfter:      return "2 Days After"
+    case .extendedDaysAfter: return "3+ Days After"
+    }
+  }
+}
+
+// MARK: - Preview
+
+#Preview("SettingsView") {
+  let pumpSiteManager = PumpSiteManager()
+  let remindersManager = RemindersManager()
+  return NavigationStack {
+    SettingsView()
+      .environmentObject(pumpSiteManager)
+      .environmentObject(remindersManager)
+  }
+  .preferredColorScheme(.light)
+}
+
+#Preview("SettingsView — dark") {
+  let pumpSiteManager = PumpSiteManager()
+  let remindersManager = RemindersManager()
+  return NavigationStack {
+    SettingsView()
+      .environmentObject(pumpSiteManager)
+      .environmentObject(remindersManager)
+  }
+  .preferredColorScheme(.dark)
+}

--- a/ChangeSite/Settings/StartDateView.swift
+++ b/ChangeSite/Settings/StartDateView.swift
@@ -1,0 +1,116 @@
+//
+//  StartDateView.swift
+//  ChangeSite
+//
+//  Created by Emily Mittleman on 5/12/26.
+//  Copyright © 2026 Emily Mittleman. All rights reserved.
+//
+
+import SwiftUI
+
+struct StartDateView: View {
+
+  @EnvironmentObject var pumpSiteManager: PumpSiteManager
+  @Environment(\.dismiss) private var dismiss
+
+  @State private var selectedDate: Date = .now
+  private let originalDate: Date
+
+  init(pumpSiteManager: PumpSiteManager) {
+    self.originalDate = pumpSiteManager.startDate
+    _selectedDate = State(initialValue: pumpSiteManager.startDate)
+  }
+
+  private var hasChanges: Bool {
+    !Calendar.current.isDate(selectedDate, equalTo: originalDate, toGranularity: .minute)
+  }
+
+  var body: some View {
+    ZStack(alignment: .top) {
+      Color.custom.background
+        .ignoresSafeArea()
+
+      VStack(spacing: 32) {
+        // Title with lightBlue bottom underline
+        VStack(alignment: .leading, spacing: 0) {
+          Text("Set Start Date")
+            .font(.rubikHeader30)
+            .foregroundColor(Color.custom.textPrimary)
+
+          Rectangle()
+            .fill(Color.custom.lightBlue)
+            .frame(height: 2)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(.horizontal, 24)
+        .padding(.top, 24)
+
+        minDatePicker
+
+        if hasChanges {
+          Button {
+            pumpSiteManager.editStartDate(from: originalDate, to: selectedDate)
+            dismiss()
+          } label: {
+            Text("Save")
+              .font(.rubikBody30)
+              .foregroundColor(Color.custom.textPrimary)
+              .frame(maxWidth: .infinity)
+              .frame(height: 56)
+              .buttonOutlineStyle()
+          }
+          .padding(.horizontal, 48)
+          .transition(.opacity)
+        }
+
+        Spacer()
+      }
+    }
+    .animation(.easeInOut(duration: 0.2), value: hasChanges)
+  }
+
+  /// Renders the correct `DatePicker` variant depending on whether there is a minimum date.
+  @ViewBuilder
+  private var minDatePicker: some View {
+    if let minDate = pumpSiteManager.getPreviousSiteEndDate() {
+      DatePicker(
+        "",
+        selection: $selectedDate,
+        in: minDate...,
+        displayedComponents: [.date, .hourAndMinute]
+      )
+      .labelsHidden()
+      .datePickerStyle(.wheel)
+      .padding(.horizontal, 24)
+    } else {
+      DatePicker(
+        "",
+        selection: $selectedDate,
+        displayedComponents: [.date, .hourAndMinute]
+      )
+      .labelsHidden()
+      .datePickerStyle(.wheel)
+      .padding(.horizontal, 24)
+    }
+  }
+}
+
+// MARK: - Preview
+
+#Preview("StartDateView") {
+  let manager = PumpSiteManager()
+  return NavigationStack {
+    StartDateView(pumpSiteManager: manager)
+      .environmentObject(manager)
+  }
+  .preferredColorScheme(.light)
+}
+
+#Preview("StartDateView — dark") {
+  let manager = PumpSiteManager()
+  return NavigationStack {
+    StartDateView(pumpSiteManager: manager)
+      .environmentObject(manager)
+  }
+  .preferredColorScheme(.dark)
+}


### PR DESCRIPTION
## Summary
- Adds `StartDateView.swift` — port of `StartDateController`; save button appears only when picker differs from original date (`.minute` granularity); calls `editStartDate(from:to:)` on save
- Adds `DefaultChangeTimeView.swift` — port of `DefaultChangeTimeController`; pre-populated with the stored default time (fixes UIKit bug that always reset to current clock time); `.hourAndMinute` picker
- Adds `ReminderFrequencyView.swift` — port of `ReminderFrequencyController`; segmented `Picker` for None/Single/Repeating; sound `Toggle`; countdown `DatePicker` for repeating interval; notifications-disabled `.alert` that reverts to the previous frequency (not `.none`) if auth is denied
- Adds `SettingsView.swift` — port of `SettingsTableViewController`; `.insetGrouped` `List` with `NavigationLink`s to the three leaf views and an inline `Stepper` for days-between
- Updates `TabItem.swift` — replaces storyboard `SettingsTableViewController` with `UIHostingController(rootView: NavigationStack { SettingsView()... })`
- Registers all four new files in `project.pbxproj`; also registers `Font+Rubik.swift` and `ButtonOutlineStyle.swift` which were missing from the project file

> **Stacked on:** `swiftui/utilities`

## Test plan
- [ ] Settings tab loads `SettingsView` with correct start date, days-between, default change time, and 5 reminder rows
- [ ] Tapping each row navigates to the correct leaf view
- [ ] Start date save disabled until picker changes; saves and dismisses correctly
- [ ] Default change time picker pre-populated with stored value (not current time)
- [ ] Reminder frequency revert works correctly when notifications are disabled
- [ ] Days-between stepper updates immediately and persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)